### PR TITLE
Add Webinars category posts to homepage carousel

### DIFF
--- a/inc/hooks/slider.php
+++ b/inc/hooks/slider.php
@@ -63,24 +63,44 @@ if (!function_exists('mlt_add_permanent_slider_content')) :
      */
     function mlt_add_permanent_slider_content($variable_slider_content_query)
     {
-
         if (is_front_page()) {
-            $permanent_slider_content_args = array(
-                'fields' => 'ids',
+            $permanent_slider_content_query = new WP_Query(array(
+                'fields'    => 'ids',
                 'post_type' => 'page',
-                'title' => 'About me',
-            );
-            $permanent_slider_content_query = new WP_Query($permanent_slider_content_args);
+                'title'     => 'About me',
+            ));
 
-            //now you got post IDs in $query->posts
-            $allTheIDs = array_merge($permanent_slider_content_query->posts, $variable_slider_content_query->posts,);
+            $webinars_query = new WP_Query(array(
+                'fields'         => 'ids',
+                'post_type'      => 'post',
+                'category_name'  => 'webinars',
+                'posts_per_page' => -1,
+            ));
+
+            $about_me_ids = $permanent_slider_content_query->posts;
+            $variable_ids = array_unique(array_merge(
+                $variable_slider_content_query->posts,
+                $webinars_query->posts,
+            ));
+
+            $sorted_variable_query = new WP_Query(array(
+                'post__in'       => array_values($variable_ids),
+                'post_type'      => 'any',
+                'orderby'        => 'date',
+                'order'          => 'DESC',
+                'posts_per_page' => -1,
+            ));
+
+            $allTheIDs = array_merge($sorted_variable_query->posts, $about_me_ids);
         } else {
             $allTheIDs = $variable_slider_content_query->posts;
         }
-        //new query, using post__in parameter
+
         $merged_query = new WP_Query(array(
-            'post__in' => $allTheIDs,
-            'post_type' => 'any',
+            'post__in'       => $allTheIDs,
+            'post_type'      => 'any',
+            'orderby'        => 'post__in',
+            'posts_per_page' => -1,
         ));
         return $merged_query;
     ?>


### PR DESCRIPTION
## Description

Extends the homepage carousel to include posts from the **Webinars** category alongside the existing blog category posts, sorted by date (newest first). The "About me" page remains pinned as the last slide regardless of its publish date.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Chore / refactor

## What was tested

1. Verified the logic flow manually: blog + webinar post IDs are merged and deduped, then sorted by date DESC via a dedicated WP_Query, and the "About me" page ID is appended last.
2. Confirmed that if the `webinars` category has no posts, `$webinars_query->posts` returns an empty array and `array_merge` handles it gracefully — no PHP warnings.
3. Confirmed the final query uses `orderby => post__in` to preserve the hand-crafted order (date-sorted posts followed by "About me").

## How to test

1. Install the theme on a local WordPress instance.
2. Create at least two posts: one in the blog category (configured in the customizer under *Slider → Category*) and one in the **Webinars** category. Give them different publish dates.
3. Set the homepage to use the front-page template.
4. Open the homepage — verify the carousel shows both the blog post and the Webinar post, ordered by publish date (newest first), with the "About me" page as the last slide.
5. Publish a newer Webinar post — reload the homepage and verify it now appears before the older blog post.
6. Remove all Webinar posts — verify the carousel still renders without errors (only blog posts + "About me").

## Technical description

`mlt_add_permanent_slider_content()` in `inc/hooks/slider.php` is the custom function that merges content into the slider query. Previously it only prepended the "About me" page before the customizer-configured category posts.

The updated function:
1. Runs a new `WP_Query` for posts in the `webinars` category (`category_name => 'webinars'`, `posts_per_page => -1`).
2. Merges the webinar IDs with the existing blog-category IDs into a deduped `$variable_ids` array.
3. Runs a second `WP_Query` on that pool with `orderby => date, order => DESC` to sort all variable posts by recency.
4. Appends the "About me" page ID(s) after the sorted pool via `array_merge`.
5. Issues the final `WP_Query` with `orderby => post__in` to preserve the exact assembled order.

## New dependencies

None.

## Risks

- The `'title' => 'About me'` WP_Query parameter (pre-existing) is non-standard and may match multiple pages if another page shares that exact title. This risk is pre-existing and out of scope for this change.
- Using `posts_per_page => -1` for the webinars query loads all webinar IDs into memory. If the Webinars category grows very large this could be a minor performance concern, but for a personal site carousel it is negligible.